### PR TITLE
chore: remove unused Button import

### DIFF
--- a/src/components/InstallPWA.tsx
+++ b/src/components/InstallPWA.tsx
@@ -1,6 +1,5 @@
 
 import React, { useState, useEffect } from 'react';
-import Button from './ui/Button';
 
 // This is a simplified approach. A more robust solution might use a library
 // or more complex browser feature detection.


### PR DESCRIPTION
## Summary
- remove unused Button import from InstallPWA component

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run typecheck` (fails: multiple TS6133, TS2322 errors)

------
https://chatgpt.com/codex/tasks/task_b_68a5164b66a0832186a7d14d5b271076