### PR TITLE
refactor: use constants for summary thresholds

### DIFF
--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import { SummaryData } from '@/types';
 
 interface SummaryCardsProps {
@@ -7,12 +7,11 @@ interface SummaryCardsProps {
 }
 
 const SummaryCards: React.FC<SummaryCardsProps> = ({ summary }) => {
-  const [threshold182, setThreshold182] = useState(182);
-  const [threshold365, setThreshold365] = useState(365);
+  const threshold182 = 182;
+  const threshold365 = 365;
 
   const renderDays = (days: number, threshold: number) => {
     const isOver = days >= threshold;
-    const wholeDays = Math.floor(days);
     return (
       <div className="flex items-baseline space-x-2">
         <span className={`text-2xl font-bold ${isOver ? 'text-brand-danger' : 'text-gray-900'}`}>{days.toFixed(2)}</span>


### PR DESCRIPTION
## Summary
- replace `useState` thresholds with constants
- drop unused `wholeDays` variable from day rendering

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68a5164c867083218400a76b242d2490