### PR TITLE
chore: remove unused Firestore import

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 
-import { collection, doc, setDoc, getDocs, deleteDoc, writeBatch } from 'firebase/firestore';
+import { collection, doc, setDoc, getDocs, deleteDoc } from 'firebase/firestore';
 import { v4 as uuidv4 } from 'uuid';
 import { db as firestoreDb } from './firebase';
 import {


### PR DESCRIPTION
## Summary
- remove unused writeBatch from Firestore imports

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68a5164dd130832197f3701ca15d6d25