### PR TITLE
chore: type next event

### DIFF
--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -1,7 +1,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getEvents, addEvent, updateEvent, deleteEvent } from '@/lib/api';
-import { NewTravelEvent, TravelEvent, UpdateTravelEvent } from '@/types';
+import { EventType, NewTravelEvent, TravelEvent, UpdateTravelEvent } from '@/types';
 import { useAuth } from './useAuth';
 import toast from 'react-hot-toast';
 
@@ -23,7 +23,7 @@ export const useEvents = () => {
 
   const sortedEvents = [...events].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
   const latestEvent = sortedEvents.length > 0 ? sortedEvents[0] : null;
-  const nextEventType = latestEvent?.type === 'ENTRY' ? 'EXIT' : 'ENTRY';
+  const nextEventType: EventType = latestEvent?.type === 'ENTRY' ? 'EXIT' : 'ENTRY';
 
   const addEventMutation = useMutation({
     mutationFn: (newEventData: NewTravelEvent) => {


### PR DESCRIPTION
## Summary
- type `nextEventType` in `useEvents`

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: tsc errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a51650a72c832187d2f85785f19507