### PR TITLE
refactor: remove unused useMemo import from Summary

### DIFF
--- a/src/pages/Summary.tsx
+++ b/src/pages/Summary.tsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useEvents } from '@/hooks/useEvents';
 import { calculateSummary, hashEvents } from '@/lib/summary';


### PR DESCRIPTION
## Summary
- simplify Summary page React import

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68a51650b83c832180269e87453ef8b2