### PR TITLE
Fix Firebase imports and typings for auth and Firestore

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import firebase from 'firebase/app';
 import { auth } from '@/lib/firebase';
+import type firebase from 'firebase/compat/app';
 
 type User = firebase.User;
 
@@ -16,7 +16,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
+    const unsubscribe = auth.onAuthStateChanged((firebaseUser: User | null) => {
       setUser(firebaseUser);
       setLoading(false);
     });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { db as firestoreDb } from './firebase';
+import type firebase from 'firebase/compat/app';
 import {
   getLocalEvents,
   putLocalEvent,
@@ -161,8 +162,8 @@ const processQueueItem = async (item: QueuedItem) => {
 
 const fetchEventsFromFirestore = async (userId: string): Promise<TravelEvent[]> => {
   const querySnapshot = await getEventsCollection(userId).get();
-  return querySnapshot.docs.map(doc => ({
-    ...doc.data() as Omit<TravelEvent, 'id'>,
+  return querySnapshot.docs.map((doc: firebase.firestore.QueryDocumentSnapshot<firebase.firestore.DocumentData>) => ({
+    ...(doc.data() as Omit<TravelEvent, 'id'>),
     id: doc.id,
   }));
 };

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
-import firebase from 'firebase/app';
-import 'firebase/auth';
-import 'firebase/firestore';
+import firebase from 'firebase/compat/app';
+import 'firebase/compat/auth';
+import 'firebase/compat/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,


### PR DESCRIPTION
## Summary
- use Firebase compat SDK and types to support username/password auth
- Type Firestore query snapshots to avoid `any` in API

## Testing
- `npm run typecheck`
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a52a4e27dc83219fb01642a0c9edc7