### PR TITLE
Restrict user events access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isOwner(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+
+    function isServiceAccount() {
+      return request.auth != null && request.auth.token.firebase != null &&
+             request.auth.token.firebase.sign_in_provider == 'firebase' &&
+             request.time != null;
+    }
+
+    match /users/{userId}/events/{eventId} {
+      allow read: if isOwner(userId);
+      allow write: if isOwner(userId) || isServiceAccount();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Restrict reads and writes on `users/{userId}/events` documents to the authenticated user
- Permit Cloud Function service account writes when signed in with the Firebase provider

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a913da91988321b5f32508f252e985