### PR TITLE
feat: add gmail token refresh helper

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      // Allow users to read their own document only if it doesn't contain OAuth tokens.
+      allow read: if request.auth != null && request.auth.uid == userId &&
+                   !resource.data.keys().hasAny(['accessToken', 'refreshToken', 'tokenExpiry']);
+      // Prevent clients from writing OAuth token fields.
+      allow create, update: if request.auth != null && request.auth.uid == userId &&
+                            !request.resource.data.keys().hasAny(['accessToken', 'refreshToken', 'tokenExpiry']);
+    }
+
+    match /users/{userId}/events/{eventId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,21 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isOwner(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+
     match /users/{userId} {
       // Allow users to read their own document only if it doesn't contain OAuth tokens.
-      allow read: if request.auth != null && request.auth.uid == userId &&
+      allow read: if isOwner(userId) &&
                    !resource.data.keys().hasAny(['accessToken', 'refreshToken', 'tokenExpiry']);
       // Prevent clients from writing OAuth token fields.
-      allow create, update: if request.auth != null && request.auth.uid == userId &&
+      allow create, update: if isOwner(userId) &&
                             !request.resource.data.keys().hasAny(['accessToken', 'refreshToken', 'tokenExpiry']);
     }
 
     match /users/{userId}/events/{eventId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if isOwner(userId);
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "traveller-functions",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "firebase-admin": "^11.11.1",
+    "firebase-functions": "^4.4.1",
+    "googleapis": "^129.0.0"
+  }
+}

--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -1,0 +1,55 @@
+import * as admin from 'firebase-admin';
+import { google } from 'googleapis';
+
+interface TokenData {
+  accessToken?: string;
+  refreshToken: string;
+  tokenExpiry?: number;
+}
+
+/**
+ * Returns a Gmail API client with a valid access token for the given user.
+ * If the stored token is missing or expired, this helper refreshes it using
+ * the Google OAuth refresh token and persists the updated credentials.
+ *
+ * This code is intended to run in a trusted environment such as a Cloud
+ * Function. Do not expose it to the client.
+ */
+export const getGmailClient = async (userId: string) => {
+  const userRef = admin.firestore().collection('users').doc(userId);
+  const snap = await userRef.get();
+  const data = snap.data() as TokenData | undefined;
+  if (!data || !data.refreshToken) {
+    throw new Error('Missing OAuth tokens for user');
+  }
+
+  let { accessToken, refreshToken, tokenExpiry } = data;
+  const now = Date.now();
+
+  const oauth2 = new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    process.env.GOOGLE_REDIRECT_URI,
+  );
+
+  if (!accessToken || !tokenExpiry || tokenExpiry <= now) {
+    oauth2.setCredentials({ refresh_token: refreshToken });
+    const { credentials } = await oauth2.refreshAccessToken();
+    accessToken = credentials.access_token || undefined;
+    tokenExpiry = credentials.expiry_date || undefined;
+    refreshToken = credentials.refresh_token || refreshToken;
+
+    await userRef.set(
+      { accessToken, refreshToken, tokenExpiry },
+      { merge: true }
+    );
+  }
+
+  oauth2.setCredentials({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expiry_date: tokenExpiry,
+  });
+
+  return google.gmail({ version: 'v1', auth: oauth2 });
+};


### PR DESCRIPTION
## Summary
- secure Firestore user docs for OAuth tokens
- add Gmail OAuth token refresh helper

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck` *(fails: missing React/JSX types)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a91426bc30832199545605e04d0222