### PR TITLE
Restrict user event access and add Firestore rule tests

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/events/{eventId} {
+      allow read, write: if isUser(userId);
+      allow write: if isCloudFunction() && request.time != null;
+    }
+  }
+}
+
+function isUser(userId) {
+  return request.auth != null && request.auth.uid == userId;
+}
+
+function isCloudFunction() {
+  return request.auth != null &&
+         request.auth.token.firebase != null &&
+         request.auth.token.firebase.sign_in_provider == 'firebase';
+}

--- a/functions/test/firestore.rules.spec.ts
+++ b/functions/test/firestore.rules.spec.ts
@@ -1,0 +1,41 @@
+import { initializeTestEnvironment, assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import fs from 'fs';
+
+describe('Firestore security rules', () => {
+  let testEnv: any;
+
+  before(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'demo-test',
+      firestore: {
+        rules: fs.readFileSync('firestore.rules', 'utf8'),
+      },
+    });
+  });
+
+  after(async () => {
+    await testEnv.cleanup();
+  });
+
+  it('allows users to access their own events', async () => {
+    const userDb = testEnv.authenticatedContext('alice').firestore();
+    const ref = userDb.collection('users').doc('alice').collection('events').doc('event1');
+    await assertSucceeds(ref.set({ created: true }));
+    await assertSucceeds(ref.get());
+  });
+
+  it('denies users from accessing other users events', async () => {
+    const userDb = testEnv.authenticatedContext('alice').firestore();
+    const ref = userDb.collection('users').doc('bob').collection('events').doc('event1');
+    await assertFails(ref.set({ created: true }));
+    await assertFails(ref.get());
+  });
+
+  it('allows cloud functions service account writes', async () => {
+    const functionDb = testEnv.authenticatedContext('serviceAccount', {
+      firebase: { sign_in_provider: 'firebase' },
+    }).firestore();
+    const ref = functionDb.collection('users').doc('bob').collection('events').doc('event1');
+    await assertSucceeds(ref.set({ created: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- scope user `users/{userId}/events` access to matching authenticated UID
- permit Cloud Function service account to write events when signed in via `firebase` provider with valid request time
- add security rule test scaffold

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix functions test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9196f4f048321a66105bb8924daa8