### PR TITLE
feat: import travel emails via Gmail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .firebase
 .DS_Store
+functions/package-lock.json

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "firebase-admin": "^11.11.1",
     "firebase-functions": "^4.4.1",
     "googleapis": "^129.0.0"

--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -16,7 +16,12 @@ interface TokenData {
  * Function. Do not expose it to the client.
  */
 export const getGmailClient = async (userId: string) => {
-  const userRef = admin.firestore().collection('users').doc(userId);
+  const tokenRef = admin
+    .firestore()
+    .collection('users')
+    .doc(userId)
+    .collection('gmailTokens')
+    .doc('tokens');
 
   const {
     GOOGLE_CLIENT_ID,
@@ -36,7 +41,7 @@ export const getGmailClient = async (userId: string) => {
   );
 
   return admin.firestore().runTransaction(async (tx) => {
-    const snap = await tx.get(userRef);
+    const snap = await tx.get(tokenRef);
     const data = snap.data() as TokenData | undefined;
     if (!data || !data.refreshToken) {
       throw new Error('Missing OAuth tokens for user');
@@ -56,7 +61,7 @@ export const getGmailClient = async (userId: string) => {
       refreshToken = credentials.refresh_token ?? refreshToken;
 
       tx.set(
-        userRef,
+        tokenRef,
         { accessToken, refreshToken, tokenExpiry },
         { merge: true },
       );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,116 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import { getGmailClient } from './gmailAuth';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { gmail_v1 } from 'googleapis';
+
+admin.initializeApp();
+
+interface TravelEvent {
+  type: 'ENTRY' | 'EXIT';
+  occurredAt: string;
+  occurredTz: string;
+  source: 'import';
+  [key: string]: unknown;
+}
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+
+const decodeBody = (body: gmail_v1.Schema$MessagePartBody | undefined): string => {
+  if (!body?.data) return '';
+  return Buffer.from(body.data, 'base64').toString('utf-8');
+};
+
+const getMessageText = (msg: gmail_v1.Schema$Message): string => {
+  const payload = msg.payload;
+  if (!payload) return '';
+  if (payload.parts && payload.parts.length > 0) {
+    return payload.parts.map((p) => decodeBody(p.body)).join('\n');
+  }
+  return decodeBody(payload.body);
+};
+
+export const importTravelEmails = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const usersSnap = await admin.firestore().collection('users').get();
+    const runAt = Date.now();
+
+    for (const user of usersSnap.docs) {
+      const userId = user.id;
+      const tokenRef = admin
+        .firestore()
+        .collection('users')
+        .doc(userId)
+        .collection('gmailTokens')
+        .doc('tokens');
+
+      try {
+        const tokenData = (await tokenRef.get()).data() as { lastSync?: number; refreshToken?: string } | undefined;
+        if (!tokenData || !tokenData.refreshToken) {
+          functions.logger.info('No Gmail tokens for user', { userId });
+          continue;
+        }
+
+        const gmail = await getGmailClient(userId);
+        const after = tokenData.lastSync ? ` after:${Math.floor(tokenData.lastSync / 1000)}` : '';
+        const q = `(label:Flights OR itinerary OR "boarding pass")${after}`;
+
+        const listRes = await gmail.users.messages.list({ userId: 'me', q });
+        const messages = listRes.data.messages ?? [];
+
+        for (const m of messages) {
+          if (!m.id) continue;
+          try {
+            const full = await gmail.users.messages.get({ userId: 'me', id: m.id, format: 'full' });
+            const body = getMessageText(full.data);
+            if (!body) continue;
+
+            const prompt = `Extract Departure, Arrival, Status from the following email. Return JSON with keys \"Departure\" ({time: <ISO>, tz: <IANA>}), \"Arrival\" ({time: <ISO>, tz: <IANA>}), and \"Status\" (ENTRY or EXIT).\n${body}`;
+            const aiRes = await model.generateContent(prompt);
+            const text = aiRes.response.text().trim();
+            const parsed = JSON.parse(text);
+
+            const event: TravelEvent =
+              parsed.Status === 'EXIT'
+                ? {
+                    type: 'EXIT',
+                    occurredAt: parsed.Departure.time,
+                    occurredTz: parsed.Departure.tz,
+                    source: 'import',
+                  }
+                : {
+                    type: 'ENTRY',
+                    occurredAt: parsed.Arrival.time,
+                    occurredTz: parsed.Arrival.tz,
+                    source: 'import',
+                  };
+
+            const eventsRef = admin.firestore().collection(`users/${userId}/events`);
+            const existing = await eventsRef
+              .where('occurredAt', '==', event.occurredAt)
+              .limit(1)
+              .get();
+            if (existing.empty) {
+              await eventsRef.add({
+                ...event,
+                userId,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              });
+              functions.logger.info('Imported travel event', { userId, occurredAt: event.occurredAt });
+            } else {
+              functions.logger.info('Duplicate event skipped', { userId, occurredAt: event.occurredAt });
+            }
+          } catch (err) {
+            functions.logger.error('Error processing message', { userId, err });
+          }
+        }
+
+        await tokenRef.set({ lastSync: runAt }, { merge: true });
+      } catch (err) {
+        functions.logger.error('Error processing user', { userId, err });
+      }
+    }
+  });


### PR DESCRIPTION
## Summary
- poll Gmail for flight-related messages using OAuth tokens stored per user
- parse message bodies with Gemini to create ENTRY/EXIT travel events
- skip duplicate events and persist new entries to Firestore
- ignore functions/package-lock.json so lockfile isn't committed

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a919bde40c83219f74a13da86cdcb9