### PR TITLE
Add Gmail OAuth connection flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from './pages/Home';
 import History from './pages/History';
 import CustomEntry from './pages/CustomEntry';
 import Summary from './pages/Summary';
+import Account from './pages/Account';
 import Auth from './pages/Auth';
 import NotFound from './pages/NotFound';
 import Layout from './components/layout/Layout';
@@ -60,6 +61,7 @@ const AppRoutes: React.FC = () => {
           <Route path="/" element={<Home />} />
           <Route path="/history" element={<History />} />
           <Route path="/summary" element={<Summary />} />
+          <Route path="/account" element={<Account />} />
           <Route path="/custom-entry" element={<CustomEntry />} />
           <Route path="/custom-entry/:id" element={<CustomEntry />} />
           <Route path="/auth" element={<Auth />} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -45,6 +45,7 @@ const Header: React.FC = () => {
                   <NavLink to="/" className={({isActive}) => `block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 ${isActive ? 'bg-gray-100' : ''}`} onClick={() => setIsMenuOpen(false)}>Home</NavLink>
                   <NavLink to="/history" className={({isActive}) => `block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 ${isActive ? 'bg-gray-100' : ''}`} onClick={() => setIsMenuOpen(false)}>History</NavLink>
                   <NavLink to="/summary" className={({isActive}) => `block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 ${isActive ? 'bg-gray-100' : ''}`} onClick={() => setIsMenuOpen(false)}>Summary</NavLink>
+                  <NavLink to="/account" className={({isActive}) => `block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 ${isActive ? 'bg-gray-100' : ''}`} onClick={() => setIsMenuOpen(false)}>Account</NavLink>
                   <button
                     onClick={handleSignOut}
                     className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -1,0 +1,31 @@
+const { VITE_GMAIL_CLIENT_ID, VITE_GMAIL_REDIRECT_URI, VITE_GMAIL_TOKEN_ENDPOINT } = import.meta.env;
+
+export const startGmailAuth = () => {
+  if (!VITE_GMAIL_CLIENT_ID || !VITE_GMAIL_REDIRECT_URI) {
+    throw new Error('Missing Gmail OAuth environment variables');
+  }
+  const params = new URLSearchParams({
+    client_id: VITE_GMAIL_CLIENT_ID,
+    redirect_uri: VITE_GMAIL_REDIRECT_URI,
+    response_type: 'code',
+    scope: 'https://www.googleapis.com/auth/gmail.readonly',
+    access_type: 'offline',
+    prompt: 'consent',
+  });
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+};
+
+export const sendGmailAuthCode = async (code: string, userId: string) => {
+  if (!VITE_GMAIL_TOKEN_ENDPOINT) {
+    throw new Error('Missing Gmail token endpoint');
+  }
+  const res = await fetch(VITE_GMAIL_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code, userId }),
+  });
+  if (!res.ok) {
+    throw new Error('Token exchange failed');
+  }
+  return res.json();
+};

--- a/src/lib/gmail.ts
+++ b/src/lib/gmail.ts
@@ -1,4 +1,5 @@
 const { VITE_GMAIL_CLIENT_ID, VITE_GMAIL_REDIRECT_URI, VITE_GMAIL_TOKEN_ENDPOINT } = import.meta.env;
+import { auth } from '@/lib/firebase';
 
 export const startGmailAuth = () => {
   if (!VITE_GMAIL_CLIENT_ID || !VITE_GMAIL_REDIRECT_URI) {
@@ -15,17 +16,34 @@ export const startGmailAuth = () => {
   window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
 };
 
-export const sendGmailAuthCode = async (code: string, userId: string) => {
+export const sendGmailAuthCode = async (code: string) => {
   if (!VITE_GMAIL_TOKEN_ENDPOINT) {
     throw new Error('Missing Gmail token endpoint');
   }
+  const user = auth.currentUser;
+  if (!user) {
+    throw new Error('User not authenticated');
+  }
+  const idToken = await user.getIdToken();
   const res = await fetch(VITE_GMAIL_TOKEN_ENDPOINT, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code, userId }),
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({ code }),
   });
   if (!res.ok) {
-    throw new Error('Token exchange failed');
+    let errorMessage = 'Token exchange failed';
+    try {
+      const errorBody = await res.json();
+      if (errorBody.error) {
+        errorMessage += `: ${errorBody.error}`;
+      }
+    } catch (_) {
+      // ignore JSON parse errors
+    }
+    throw new Error(errorMessage);
   }
   return res.json();
 };

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -24,12 +24,12 @@ const Account: React.FC = () => {
 
     if (code && user) {
       setLoading(true);
-      sendGmailAuthCode(code, user.uid)
+      sendGmailAuthCode(code)
         .then(() => {
           toast.success('Gmail connected');
         })
-        .catch(() => {
-          toast.error('Failed to connect Gmail');
+        .catch((err: Error) => {
+          toast.error(err.message || 'Failed to connect Gmail');
         })
         .finally(() => {
           setLoading(false);

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import toast from 'react-hot-toast';
+import { startGmailAuth, sendGmailAuthCode } from '@/lib/gmail';
+import { useAuth } from '@/hooks/useAuth';
+
+const Account: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { user } = useAuth();
+
+  const handleConnect = () => {
+    try {
+      startGmailAuth();
+    } catch (e) {
+      toast.error('Missing Gmail configuration');
+    }
+  };
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const error = searchParams.get('error');
+
+    if (code && user) {
+      setLoading(true);
+      sendGmailAuthCode(code, user.uid)
+        .then(() => {
+          toast.success('Gmail connected');
+        })
+        .catch(() => {
+          toast.error('Failed to connect Gmail');
+        })
+        .finally(() => {
+          setLoading(false);
+          setSearchParams({});
+        });
+    } else if (error) {
+      toast.error('Gmail authorization failed');
+      setSearchParams({});
+    }
+  }, [searchParams, user, setSearchParams]);
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Account</h1>
+      <Button onClick={handleConnect} isLoading={loading} className="w-full">
+        Connect Gmail
+      </Button>
+    </div>
+  );
+};
+
+export default Account;


### PR DESCRIPTION
## Summary
- add backend function to exchange Gmail OAuth codes and store tokens
- expose Gmail OAuth helpers and account page with "Connect Gmail" control
- wire up navigation for account management

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: No test files found)*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_b_68a922d46784832193d3ee5728e31498