### PR TITLE
feat: add Gmail OAuth code exchange function

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,5 +17,9 @@ service cloud.firestore {
     match /users/{userId}/events/{eventId} {
       allow read, write: if isOwner(userId);
     }
+
+    match /users/{userId}/gmailTokens/{tokenDoc} {
+      allow read, write: if false;
+    }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -13,6 +14,8 @@
     "googleapis": "^129.0.0"
   },
   "devDependencies": {
+    "firebase-functions-test": "^3.1.0",
+    "vitest": "^1.6.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }

--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -7,6 +7,25 @@ interface TokenData {
   tokenExpiry?: number;
 }
 
+export const createOAuth2Client = () => {
+  const {
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    GOOGLE_REDIRECT_URI,
+  } = process.env;
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_REDIRECT_URI) {
+    throw new Error(
+      'Missing one or more required Google OAuth environment variables: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI',
+    );
+  }
+
+  return new google.auth.OAuth2(
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    GOOGLE_REDIRECT_URI,
+  );
+};
+
 /**
  * Returns a Gmail API client with a valid access token for the given user.
  * If the stored token is missing or expired, this helper refreshes it using
@@ -23,22 +42,7 @@ export const getGmailClient = async (userId: string) => {
     .collection('gmailTokens')
     .doc('tokens');
 
-  const {
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET,
-    GOOGLE_REDIRECT_URI,
-  } = process.env;
-  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_REDIRECT_URI) {
-    throw new Error(
-      'Missing one or more required Google OAuth environment variables: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI',
-    );
-  }
-
-  const oauth2 = new google.auth.OAuth2(
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET,
-    GOOGLE_REDIRECT_URI,
-  );
+  const oauth2 = createOAuth2Client();
 
   return admin.firestore().runTransaction(async (tx) => {
     const snap = await tx.get(tokenRef);

--- a/functions/test/exchangeGmailCode.test.ts
+++ b/functions/test/exchangeGmailCode.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import firebaseFunctionsTest from 'firebase-functions-test';
+
+vi.mock('firebase-admin', () => ({
+  initializeApp: vi.fn(),
+  firestore: vi.fn(),
+}));
+
+vi.mock('../src/gmailAuth', () => ({
+  createOAuth2Client: vi.fn(),
+}));
+
+import * as admin from 'firebase-admin';
+import { createOAuth2Client } from '../src/gmailAuth';
+
+const fft = firebaseFunctionsTest();
+let exchangeGmailCode: any;
+
+describe('exchangeGmailCode', () => {
+  beforeAll(async () => {
+    process.env.GEMINI_API_KEY = 'test';
+    ({ exchangeGmailCode } = await import('../src/index'));
+  });
+
+  afterAll(() => {
+    fft.cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stores tokens and returns success', async () => {
+    const getToken = vi.fn().mockResolvedValue({
+      tokens: { refresh_token: 'r', access_token: 'a', expiry_date: 123 },
+    });
+    (createOAuth2Client as unknown as vi.Mock).mockReturnValue({ getToken });
+
+    const set = vi.fn().mockResolvedValue(undefined);
+    (admin.firestore as unknown as vi.Mock).mockReturnValue({
+      collection: vi.fn().mockReturnValue({
+        doc: vi.fn().mockReturnValue({
+          collection: vi.fn().mockReturnValue({
+            doc: vi.fn().mockReturnValue({ set }),
+          }),
+        }),
+      }),
+    });
+
+    const wrapped = fft.wrap(exchangeGmailCode);
+    const res = await wrapped({ authCode: 'code' }, { auth: { uid: 'uid' } });
+
+    expect(getToken).toHaveBeenCalledWith('code');
+    expect(set).toHaveBeenCalledWith({
+      refreshToken: 'r',
+      accessToken: 'a',
+      tokenExpiry: 123,
+    });
+    expect(res).toEqual({ success: true });
+  });
+
+  it('fails for unauthenticated users', async () => {
+    const wrapped = fft.wrap(exchangeGmailCode);
+    await expect(wrapped({ authCode: 'code' })).rejects.toMatchObject({ code: 'unauthenticated' });
+  });
+
+  it('fails for invalid input', async () => {
+    const wrapped = fft.wrap(exchangeGmailCode);
+    await expect(wrapped({}, { auth: { uid: 'uid' } })).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  it('fails when Google returns incomplete tokens', async () => {
+    (createOAuth2Client as unknown as vi.Mock).mockReturnValue({
+      getToken: vi.fn().mockResolvedValue({ tokens: {} }),
+    });
+    const wrapped = fft.wrap(exchangeGmailCode);
+    await expect(wrapped({ authCode: 'code' }, { auth: { uid: 'uid' } })).rejects.toMatchObject({ code: 'internal' });
+  });
+
+  it('fails when token exchange throws', async () => {
+    (createOAuth2Client as unknown as vi.Mock).mockReturnValue({
+      getToken: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const wrapped = fft.wrap(exchangeGmailCode);
+    await expect(wrapped({ authCode: 'code' }, { auth: { uid: 'uid' } })).rejects.toMatchObject({ code: 'internal' });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared OAuth2 client factory
- add `exchangeGmailCode` callable to store Gmail tokens

## Testing
- `npm test` *(fails: No test files found)*
- `cd functions && npm test` *(fails: Missing script)*
- `cd functions && npm run build` *(fails: Cannot find module 'firebase-admin')*


------
https://chatgpt.com/codex/tasks/task_b_68a922fd7c1483219c06e0d7b897526d