### PR TITLE
feat: add Gmail code exchange function

### DIFF
--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -4,10 +4,18 @@ import { google } from 'googleapis';
  * Preconfigured OAuth2 client for Gmail operations.
  * Client ID, secret, and redirect URI are pulled from environment variables.
  */
+const { GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REDIRECT_URI } = process.env;
+
+if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REDIRECT_URI) {
+  throw new Error(
+    'Missing required Gmail OAuth2 environment variables. Ensure GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, and GMAIL_REDIRECT_URI are set.'
+  );
+}
+
 const oauth2Client = new google.auth.OAuth2(
-  process.env.GMAIL_CLIENT_ID,
-  process.env.GMAIL_CLIENT_SECRET,
-  process.env.GMAIL_REDIRECT_URI
+  GMAIL_CLIENT_ID,
+  GMAIL_CLIENT_SECRET,
+  GMAIL_REDIRECT_URI
 );
 
 export default oauth2Client;

--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -1,0 +1,13 @@
+import { google } from 'googleapis';
+
+/**
+ * Preconfigured OAuth2 client for Gmail operations.
+ * Client ID, secret, and redirect URI are pulled from environment variables.
+ */
+const oauth2Client = new google.auth.OAuth2(
+  process.env.GMAIL_CLIENT_ID,
+  process.env.GMAIL_CLIENT_SECRET,
+  process.env.GMAIL_REDIRECT_URI
+);
+
+export default oauth2Client;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,29 +13,49 @@ export const exchangeGmailCode = functions.https.onCall(async (data, context) =>
   const authCode: string | undefined = data?.authCode;
   const uid = context.auth?.uid;
 
-  if (!authCode || !uid) {
-    return { success: false, error: 'Missing auth code or user not authenticated' };
+  if (!uid) {
+    throw new functions.https.HttpsError(
+      'unauthenticated',
+      'The function must be called by an authenticated user.'
+    );
+  }
+
+  if (!authCode) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'The function must be called with an "authCode" argument.'
+    );
   }
 
   try {
     const { tokens } = await oauth2Client.getToken(authCode);
     const { refresh_token, access_token, expiry_date } = tokens;
 
+    if (!access_token) {
+      throw new functions.https.HttpsError(
+        'internal',
+        'Failed to retrieve access token from Google.'
+      );
+    }
+
     await admin
       .firestore()
       .doc(`users/${uid}/gmailTokens/tokens`)
       .set(
         {
-          refreshToken: refresh_token,
           accessToken: access_token,
           tokenExpiry: expiry_date,
+          ...(refresh_token && { refreshToken: refresh_token }),
         },
         { merge: true }
       );
 
     return { success: true };
   } catch (err) {
-    functions.logger.error('Failed to exchange Gmail code', err);
-    return { success: false, error: (err as Error).message };
+    functions.logger.error(`Failed to exchange Gmail code for user ${uid}`, err);
+    throw new functions.https.HttpsError(
+      'internal',
+      'Failed to exchange authorization code.'
+    );
   }
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,41 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import oauth2Client from './gmailAuth';
+
+admin.initializeApp();
+
+/**
+ * HTTPS callable function to exchange a Gmail auth code for tokens.
+ * Persists the resulting refresh and access tokens to Firestore under the
+ * authenticated user's document.
+ */
+export const exchangeGmailCode = functions.https.onCall(async (data, context) => {
+  const authCode: string | undefined = data?.authCode;
+  const uid = context.auth?.uid;
+
+  if (!authCode || !uid) {
+    return { success: false, error: 'Missing auth code or user not authenticated' };
+  }
+
+  try {
+    const { tokens } = await oauth2Client.getToken(authCode);
+    const { refresh_token, access_token, expiry_date } = tokens;
+
+    await admin
+      .firestore()
+      .doc(`users/${uid}/gmailTokens/tokens`)
+      .set(
+        {
+          refreshToken: refresh_token,
+          accessToken: access_token,
+          tokenExpiry: expiry_date,
+        },
+        { merge: true }
+      );
+
+    return { success: true };
+  } catch (err) {
+    functions.logger.error('Failed to exchange Gmail code', err);
+    return { success: false, error: (err as Error).message };
+  }
+});


### PR DESCRIPTION
## Summary
- add OAuth2 client helper for Gmail
- add `exchangeGmailCode` Cloud Function to exchange auth code and store tokens in Firestore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a93f8eb3908321be6dc5849ad774c0