### PR TITLE
feat(functions): add Gmail auth code exchange

### DIFF
--- a/functions/src/gmailAuth.ts
+++ b/functions/src/gmailAuth.ts
@@ -7,6 +7,25 @@ interface TokenData {
   tokenExpiry?: number;
 }
 
+export const getOAuth2Client = () => {
+  const {
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    GOOGLE_REDIRECT_URI,
+  } = process.env;
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_REDIRECT_URI) {
+    throw new Error(
+      'Missing one or more required Google OAuth environment variables: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI',
+    );
+  }
+
+  return new google.auth.OAuth2(
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    GOOGLE_REDIRECT_URI,
+  );
+};
+
 /**
  * Returns a Gmail API client with a valid access token for the given user.
  * If the stored token is missing or expired, this helper refreshes it using
@@ -23,22 +42,7 @@ export const getGmailClient = async (userId: string) => {
     .collection('gmailTokens')
     .doc('tokens');
 
-  const {
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET,
-    GOOGLE_REDIRECT_URI,
-  } = process.env;
-  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_REDIRECT_URI) {
-    throw new Error(
-      'Missing one or more required Google OAuth environment variables: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI',
-    );
-  }
-
-  const oauth2 = new google.auth.OAuth2(
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET,
-    GOOGLE_REDIRECT_URI,
-  );
+  const oauth2 = getOAuth2Client();
 
   return admin.firestore().runTransaction(async (tx) => {
     const snap = await tx.get(tokenRef);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -56,15 +56,15 @@ export const exchangeGmailCode = functions.https.onRequest(async (req, res) => {
     return;
   }
 
-  const { authCode } = req.body as { authCode?: string };
-  if (!authCode) {
-    res.status(400).json({ success: false, error: 'Missing auth code' });
+  const code = req.body?.code;
+  if (typeof code !== 'string' || code.length === 0) {
+    res.status(400).json({ success: false, error: 'Missing or invalid auth code' });
     return;
   }
 
   try {
     const oauth2 = getOAuth2Client();
-    const { tokens } = await oauth2.getToken(authCode);
+    const { tokens } = await oauth2.getToken(code);
     if (!tokens.refresh_token) {
       res.status(500).json({ success: false, error: 'No refresh token returned' });
       return;


### PR DESCRIPTION
## Summary
- add `exchangeGmailCode` HTTPS function to trade Google auth code for tokens and persist in Firestore
- centralize OAuth2 client configuration via `getOAuth2Client`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_b_68a9b707bc6083218995d60331980015