### PR TITLE
fix ESM import for Gmail auth

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,6 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
-import { getGmailClient, getOAuth2Client } from './gmailAuth';
+import { getGmailClient, getOAuth2Client } from './gmailAuth.js';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { gmail_v1 } from 'googleapis';
 

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "lib",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- use .js extension for Gmail auth import to satisfy Node ESM resolution
- configure TypeScript to Node16 module and resolution for functions

## Testing
- `npm --prefix functions run build`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9e0740388832198eb22b5ab13bdab