### PR TITLE
Fix firebase-admin import for ESM functions

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 import * as functions from 'firebase-functions';
-import * as admin from 'firebase-admin';
+import admin from 'firebase-admin';
 import { getGmailClient, getOAuth2Client } from './gmailAuth.js';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { gmail_v1 } from 'googleapis';


### PR DESCRIPTION
## Summary
- fix firebase-admin usage in Cloud Functions by switching to default import

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_b_68a9e849db5c83218d2dc767df67915a