### PR TITLE
fix: update Firebase Functions imports

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -15,6 +15,9 @@
         "@types/node": "^20.8.10",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": "20"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,6 +12,7 @@
         "googleapis": "^129.0.0"
       },
       "devDependencies": {
+        "@types/node": "^20.8.10",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
@@ -512,12 +513,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1248,12 +1249,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/firebase-admin/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
     },
     "node_modules/firebase-functions": {
       "version": "6.4.0",
@@ -2770,9 +2765,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "main": "lib/index.js",
+  "engines": {
+    "node": "20"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
     "googleapis": "^129.0.0"
   },
   "devDependencies": {
+    "@types/node": "^20.8.10",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
-import { onRequest } from 'firebase-functions/https';
-import { onSchedule } from 'firebase-functions/scheduler';
+import { onRequest } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { defineSecret } from 'firebase-functions/params';
 import { logger } from 'firebase-functions';
 import admin from 'firebase-admin';


### PR DESCRIPTION
## Summary
- use Firebase Functions v2 https/scheduler modules
- add @types/node to support Node globals

## Testing
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_b_68aac9f3be1c8321916c5213dd4ac1de