### PR TITLE
chore: upgrade Firebase Functions to Node 22 and v6 SDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 functions/.env
 .firebase
 .DS_Store
-functions/package-lock.json
 functions/node_modules
 functions/lib
 package-lock.json

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "functions": {
     "source": "functions",
+    "runtime": "nodejs22",
     "predeploy": ["npm --prefix functions run build"]
   },
   "hosting": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,17 +7,18 @@
       "name": "traveller-functions",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
-        "firebase-admin": "latest",
-        "firebase-functions": "latest",
+        "firebase-admin": "^13.4.0",
+        "firebase-functions": "^6.4.0",
         "googleapis": "^129.0.0"
       },
       "devDependencies": {
-        "@types/node": "^20.8.10",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "@types/express": "^4.17.23",
+        "@types/node": "^22.17.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -516,9 +517,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1242,15 +1243,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.14.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/firebase-functions": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,21 +4,21 @@
   "type": "module",
   "main": "lib/index.js",
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "scripts": {
     "build": "tsc"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "firebase-admin": "latest",
-    "firebase-functions": "^5.1.0",
+    "firebase-admin": "^13.4.0",
+    "firebase-functions": "^6.4.0",
     "googleapis": "^129.0.0"
   },
   "devDependencies": {
-    "@types/express": "^4",
-    "@types/node": "^20.8.10",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "@types/express": "^4.17.23",
+    "@types/node": "^22.17.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { gmail_v1 } from 'googleapis';
 import type { Request, Response } from 'express';
 
-setGlobalOptions({ region: 'us-central1' });
+setGlobalOptions({ region: defineString('FUNCTIONS_REGION', { default: 'us-central1' }).value() });
 admin.initializeApp();
 
 export const GEMINI_API_KEY = defineSecret('GEMINI_API_KEY');

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,6 @@
 import { onRequest } from 'firebase-functions/v2/https';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { setGlobalOptions } from 'firebase-functions/v2';
 import { defineSecret, defineString } from 'firebase-functions/params';
 import { logger } from 'firebase-functions';
 import admin from 'firebase-admin';
@@ -8,6 +9,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { gmail_v1 } from 'googleapis';
 import type { Request, Response } from 'express';
 
+setGlobalOptions({ region: 'us-central1' });
 admin.initializeApp();
 
 export const GEMINI_API_KEY = defineSecret('GEMINI_API_KEY');

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "lib",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- target Cloud Functions runtime Node.js 22 and pin new Firebase SDK majors
- add global options setup for v2 API
- refresh functions lockfile and TypeScript config for Node 22

## Testing
- `npm install` (warn: engine mismatch, uses Node v20.19.4)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68aad4ad2e7083219f78d3dcc13b5fde